### PR TITLE
Apply JS admin monkeypatch only when in admin

### DIFF
--- a/smart_selects/widgets.py
+++ b/smart_selects/widgets.py
@@ -128,11 +128,13 @@ class ChainedSelect(Select):
                     fill_field(val, start_value);
                 })
             })
-            var oldDismissAddAnotherPopup = dismissAddAnotherPopup;
-            dismissAddAnotherPopup = function(win, newId, newRepr) {
-                oldDismissAddAnotherPopup(win, newId, newRepr);
-                if (windowname_to_id(win.name) == "id_%(chainfield)s") {
-                    $("#id_%(chainfield)s").change();
+            if (typeof(dismissAddAnotherPopup) !== 'undefined') {
+                var oldDismissAddAnotherPopup = dismissAddAnotherPopup;
+                dismissAddAnotherPopup = function(win, newId, newRepr) {
+                    oldDismissAddAnotherPopup(win, newId, newRepr);
+                    if (windowname_to_id(win.name) == "id_%(chainfield)s") {
+                        $("#id_%(chainfield)s").change();
+                    }
                 }
             }
         })(jQuery || django.jQuery);


### PR DESCRIPTION
Because only admin forms use dismissAddAnotherPopup, it's undefined
in regular forms.  That in turn results in
"Uncaught ReferenceError: dismissAddAnotherPopup is not defined." when
loading chained widgets.
