### PR TITLE
Fix "DeprecationWarning: django.conf.urls.defaults is deprecated"

### DIFF
--- a/smart_selects/urls.py
+++ b/smart_selects/urls.py
@@ -1,7 +1,7 @@
 try:
-    from django.conf.urls.defaults import *
-except ImportError:
     from django.conf.urls import *
+except ImportError: # django < 1.4
+    from django.conf.urls.defaults import *
 
 urlpatterns = patterns('smart_selects.views',
     url(r'^all/(?P<app>[\w\-]+)/(?P<model>[\w\-]+)/(?P<field>[\w\-]+)/(?P<value>[\w\-]+)/$', 'filterchain_all', name='chained_filter_all'),


### PR DESCRIPTION
Hi,

I modified urls.py to make it try to import django.conf.urls first and then django.conf.urls.defaults (which is deprecated but used with django < 1.4).

Have a good day !
Fabien