### PR TITLE
Adds test script and basic tests of deconstruct() methods, fixes CachedStaticFilesStorage collectstatic crash

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name="django-smart-selects",
-      version="1.0.9.3",
+      version="1.0.9.4",
       description="Django application to handle chained model fields.",
       author="Patrick Lauber",
       packages=find_packages(),

--- a/smart_selects/tests.py
+++ b/smart_selects/tests.py
@@ -6,8 +6,7 @@ from db_fields import ChainedForeignKey, GroupedForeignKey
 
 
 def has_new_migrations():
-    django_version = float('%d.%d' % django.VERSION[:2])
-    return (django_version >= 1.7,
+    return (django.VERSION[:2] >= (1, 7),
             "This test requires Django migrations introduced in Django 1.7.")
 
 

--- a/smart_selects/tests.py
+++ b/smart_selects/tests.py
@@ -1,0 +1,55 @@
+import unittest
+
+from db_fields import ChainedForeignKey, GroupedForeignKey
+
+
+class AssertReconstructibleMixin(object):
+    def _assert_reconstructible(self, *field_args, **field_kwargs):
+        field_instance = self.field_class(*field_args, **field_kwargs)
+        name, path, args, kwargs = field_instance.deconstruct()
+        new_instance = self.field_class(*args, **kwargs)
+
+        for attr_name in self.deconstruct_attrs:
+            self.assertEqual(
+                getattr(field_instance, attr_name),
+                getattr(new_instance, attr_name)
+            )
+
+
+class ChainedForeignKeyTests(AssertReconstructibleMixin, unittest.TestCase):
+    def setUp(self):
+        self.field_class = ChainedForeignKey
+        self.deconstruct_attrs = [
+            'chain_field', 'model_field', 'show_all', 'auto_choose',
+            'view_name',
+        ]
+
+    def test_deconstruct_basic(self):
+        self._assert_reconstructible(
+            'myapp.MyModel',
+            chained_field='a_chained_field',
+            chained_model_field='the_chained_model_field',
+            show_all=False, auto_choose=True
+        )
+
+    def test_deconstruct_mostly_default(self):
+        self._assert_reconstructible(
+            'myapp.MyModel'
+        )
+
+    def test_deconstruct_non_default(self):
+        self._assert_reconstructible(
+            'myapp.MyModel',
+            chained_field='a_chained_field',
+            chained_model_field='the_chained_model_field',
+            show_all=True, auto_choose=True
+        )
+
+
+class GroupedForeignKeyTests(AssertReconstructibleMixin, unittest.TestCase):
+    def setUp(self):
+        self.field_class = GroupedForeignKey
+        self.deconstruct_attrs = ['group_field']
+
+    def test_deconstruct_basic(self):
+        self._assert_reconstructible('myapp.MyModel', 'the_group_field')

--- a/smart_selects/tests.py
+++ b/smart_selects/tests.py
@@ -11,7 +11,7 @@ def has_new_migrations():
 
 
 class AssertReconstructibleMixin(object):
-    def _assert_reconstructible(self, *field_args, **field_kwargs):
+    def assert_reconstructible(self, *field_args, **field_kwargs):
         field_instance = self.field_class(*field_args, **field_kwargs)
         name, path, args, kwargs = field_instance.deconstruct()
         new_instance = self.field_class(*args, **kwargs)
@@ -33,7 +33,7 @@ class ChainedForeignKeyTests(AssertReconstructibleMixin, unittest.TestCase):
         ]
 
     def test_deconstruct_basic(self):
-        self._assert_reconstructible(
+        self.assert_reconstructible(
             'myapp.MyModel',
             chained_field='a_chained_field',
             chained_model_field='the_chained_model_field',
@@ -41,12 +41,12 @@ class ChainedForeignKeyTests(AssertReconstructibleMixin, unittest.TestCase):
         )
 
     def test_deconstruct_mostly_default(self):
-        self._assert_reconstructible(
+        self.assert_reconstructible(
             'myapp.MyModel'
         )
 
     def test_deconstruct_non_default(self):
-        self._assert_reconstructible(
+        self.assert_reconstructible(
             'myapp.MyModel',
             chained_field='a_chained_field',
             chained_model_field='the_chained_model_field',
@@ -61,4 +61,4 @@ class GroupedForeignKeyTests(AssertReconstructibleMixin, unittest.TestCase):
         self.deconstruct_attrs = ['group_field']
 
     def test_deconstruct_basic(self):
-        self._assert_reconstructible('myapp.MyModel', 'the_group_field')
+        self.assert_reconstructible('myapp.MyModel', 'the_group_field')

--- a/smart_selects/tests.py
+++ b/smart_selects/tests.py
@@ -1,6 +1,14 @@
 import unittest
 
+import django
+
 from db_fields import ChainedForeignKey, GroupedForeignKey
+
+
+def has_new_migrations():
+    django_version = float('%d.%d' % django.VERSION[:2])
+    return (django_version >= 1.7,
+            "This test requires Django migrations introduced in Django 1.7.")
 
 
 class AssertReconstructibleMixin(object):
@@ -16,6 +24,7 @@ class AssertReconstructibleMixin(object):
             )
 
 
+@unittest.skipUnless(*has_new_migrations())
 class ChainedForeignKeyTests(AssertReconstructibleMixin, unittest.TestCase):
     def setUp(self):
         self.field_class = ChainedForeignKey
@@ -46,6 +55,7 @@ class ChainedForeignKeyTests(AssertReconstructibleMixin, unittest.TestCase):
         )
 
 
+@unittest.skipUnless(*has_new_migrations())
 class GroupedForeignKeyTests(AssertReconstructibleMixin, unittest.TestCase):
     def setUp(self):
         self.field_class = GroupedForeignKey

--- a/smart_selects/widgets.py
+++ b/smart_selects/widgets.py
@@ -7,6 +7,7 @@ from django.contrib.admin.templatetags.admin_static import static
 from django.core.urlresolvers import reverse
 from django.db.models import get_model
 from django.forms.widgets import Select
+from django import forms
 from django.utils.safestring import mark_safe
 
 from smart_selects.utils import unicode_sorter
@@ -36,7 +37,9 @@ class ChainedSelect(Select):
         self.view_name = view_name
         super(Select, self).__init__(*args, **kwargs)
 
-    class Media:
+    @property
+    def media(self):
+        """Media defined as a dynamic property instead of an inner class."""
         extra = '' if settings.DEBUG else '.min'
         js = [
             'jquery%s.js' % extra,
@@ -46,6 +49,8 @@ class ChainedSelect(Select):
             js = [static('admin/js/%s' % url) for url in js]
         elif JQUERY_URL:
             js = [JQUERY_URL]
+
+        return forms.Media(js=js)
 
     def render(self, name, value, attrs=None, choices=()):
         if len(name.split('-')) > 1:  # formset

--- a/test.py
+++ b/test.py
@@ -1,0 +1,15 @@
+if __name__ == '__main__':
+    from django.conf import settings
+    settings.configure(
+        DATABASES={'default': {
+            'NAME': ':memory:', 'ENGINE': 'django.db.backends.sqlite3'
+        }},
+        INSTALLED_APPS=('smart_selects',),
+        MIDDLEWARE_CLASSES=(),
+    )
+    from django.core.management import call_command
+    import django
+
+    if django.VERSION[:2] >= (1, 7):
+        django.setup()
+    call_command('test', 'smart_selects')


### PR DESCRIPTION
deconstruct() methods won't work on Django  versions < 1.7, so these tests are skipped when not running on Django 1.7+.