### PR TITLE
Implement ChainedManyToMany

### DIFF
--- a/smart_selects/db_fields.py
+++ b/smart_selects/db_fields.py
@@ -1,4 +1,4 @@
-from django.db.models.fields.related import ForeignKey
+from django.db.models.fields.related import ForeignKey, ManyToManyField
 
 try:
     from south.modelsinspector import add_introspection_rules
@@ -8,6 +8,77 @@ except ImportError:
 
 
 from smart_selects import form_fields
+
+class ChainedManyToManyField(ManyToManyField):
+    """
+    chains the choices of a previous combo box with this ManyToMany
+    """
+    def __init__(self, to, chained_field=None, chained_model_field=None,
+                 show_all=False, auto_choose=False, view_name=None, **kwargs):
+        if isinstance(to, basestring):
+            self.app_name, self.model_name = to.split('.')
+        else:
+            self.app_name = to._meta.app_label
+            self.model_name = to._meta.object_name
+        self.chain_field = chained_field
+        self.model_field = chained_model_field
+        self.show_all = show_all
+        self.auto_choose = auto_choose
+        self.view_name = view_name
+        ManyToManyField.__init__(self, to, **kwargs)
+
+    def deconstruct(self):
+        field_name, path, args, kwargs = super(
+            ChainedManyToMany, self).deconstruct()
+
+        # Maps attribute names to their default kwarg values.
+        defaults = {
+            'chain_field': None,
+            'model_field': None,
+            'show_all': False,
+            'auto_choose': False,
+            'view_name': None,
+        }
+
+        # Maps attribute names to their __init__ kwarg names.
+        attr_to_kwarg_names = {
+            'chain_field': 'chained_field',
+            'model_field': 'chained_model_field',
+            'show_all': 'show_all',
+            'auto_choose': 'auto_choose',
+            'view_name': 'view_name',
+        }
+
+        for name, default in defaults.items():
+            value = getattr(self, name)
+            kwarg_name = attr_to_kwarg_names[name]
+
+            # None and Boolean defaults should use an 'is' comparison.
+            if value is not default:
+                kwargs[kwarg_name] = value
+            else:
+                # value is default, so don't include it in serialized kwargs.
+                if kwarg_name in kwargs:
+                    del kwargs[kwarg_name]
+
+        return field_name, path, args, kwargs
+
+    def formfield(self, **kwargs):
+
+        defaults = {
+            'form_class': form_fields.ChainedManyToManyField,
+            'queryset': self.rel.to._default_manager.complex_filter(
+                self.rel.limit_choices_to),
+            'app_name': self.app_name,
+            'model_name': self.model_name,
+            'chain_field': self.chain_field,
+            'model_field': self.model_field,
+            'show_all': self.show_all,
+            'auto_choose': self.auto_choose,
+            'view_name': self.view_name,
+        }
+        defaults.update(kwargs)
+        return super(ChainedManyToManyField, self).formfield(**defaults)
 
 
 class ChainedForeignKey(ForeignKey):

--- a/smart_selects/db_fields.py
+++ b/smart_selects/db_fields.py
@@ -29,7 +29,7 @@ class ChainedManyToManyField(ManyToManyField):
 
     def deconstruct(self):
         field_name, path, args, kwargs = super(
-            ChainedManyToMany, self).deconstruct()
+            ChainedManyToManyField, self).deconstruct()
 
         # Maps attribute names to their default kwarg values.
         defaults = {

--- a/smart_selects/db_fields.py
+++ b/smart_selects/db_fields.py
@@ -197,7 +197,8 @@ if has_south:
             'group_field': ['group_field', {}],
         },
     )]
-
+    add_introspection_rules([],
+                            ["^smart_selects\.db_fields\.ChainedManyToManyField"])
     add_introspection_rules([],
                             ["^smart_selects\.db_fields\.ChainedForeignKey"])
     add_introspection_rules(rules_grouped,

--- a/smart_selects/static/smart-selects/admin/js/chainedm2m.js
+++ b/smart_selects/static/smart-selects/admin/js/chainedm2m.js
@@ -1,0 +1,90 @@
+
+(function($) {
+    chainedm2m = function() {
+        return {
+            fireEvent: function(element,event) {
+                if (document.createEventObject){
+                    // dispatch for IE
+                    var evt = document.createEventObject();
+                    return element.fireEvent('on'+event,evt)
+                }
+                else{
+                    // dispatch for firefox + others
+                    var evt = document.createEvent("HTMLEvents");
+                    evt.initEvent(event, true, true ); // event type,bubbling,cancelable
+                    return !element.dispatchEvent(evt);
+                }
+            },
+
+            dismissRelatedLookupPopup: function(win, chosenId) {
+                var name = windowname_to_id(win.name);
+                var elem = document.getElementById(name);
+                if (elem.className.indexOf('vManyToManyRawIdAdminField') != -1 && elem.value) {
+                    elem.value += ',' + chosenId;
+                } else {
+                    elem.value = chosenId;
+                }
+                fireEvent(elem, 'change');
+                win.close();
+            },
+
+            fill_field: function(val, initial_value, elem_id, url, initial_parent, auto_choose){
+                var target_url = url + "/" + val + "/";
+                $.getJSON(target_url, function(j){
+                    var options = '';
+
+                    for (var i = 0; i < j.length; i++) {
+                        options += '<option value="' + j[i].value + '">' + j[i].display + '<'+'/option>';
+                    }
+                    var width = $(elem_id).outerWidth();
+                    $(elem_id).html(options);
+                    if (navigator.appVersion.indexOf("MSIE") != -1)
+                        $(elem_id).width(width + 'px');
+                    var auto_choose = auto_choose;
+
+                    if(val == initial_parent){
+                        for (var i = 0; i < initial_value.length; i++) {
+                            $(elem_id + ' option[value="'+ initial_value[i] +'"]').attr('selected', 'selected');
+                        }
+                    }
+                    if(auto_choose && j.length == 1){
+                        $(elem_id + ' option[value="'+ j[0].value +'"]').attr('selected', 'selected');
+                    }
+
+                    $(elem_id).trigger('change');
+
+                    if ($.fn.chosen !== undefined) {
+                        $(elem_id).trigger('chosen:updated');
+                    }
+                })
+            },
+
+            init: function(chainfield, url, id, value, auto_choose) {
+                var initial_parent = $(chainfield).val();
+                var initial_value = value;
+
+                if(!$(chainfield).hasClass("chained")){
+                    var val = $(chainfield).val();
+                    this.fill_field(val, initial_value, id, url, initial_parent, auto_choose);
+                }
+                var fill_field = this.fill_field;
+                $(chainfield).change(function(){
+                    var val = $(this).val();
+                    fill_field(val, initial_value, id, url, initial_parent, auto_choose);
+                })
+
+                // allait en bas, hors du documentready
+                if (typeof(dismissAddAnotherPopup) !== 'undefined') {
+                    var oldDismissAddAnotherPopup = dismissAddAnotherPopup;
+                    dismissAddAnotherPopup = function(win, newId, newRepr) {
+                        oldDismissAddAnotherPopup(win, newId, newRepr);
+                        if ("#" + windowname_to_id(win.name) == chainfield) {
+                            $(chainfield).change();
+                        }
+                    }
+                }
+
+            }
+        }
+    }();
+})(jQuery || django.jQuery);

--- a/smart_selects/utils.py
+++ b/smart_selects/utils.py
@@ -37,9 +37,11 @@ def serialize_results(results):
     ]
 
 
-def get_keywords(field, value):
+def get_keywords(field, value, m2m=False):
     if value == '0':
         keywords = {str("%s__isnull" % field): True}
+    elif m2m:
+        keywords = {str("%s__pk" % field): str(value)}
     else:
         keywords = {str(field): str(value)}
 

--- a/smart_selects/views.py
+++ b/smart_selects/views.py
@@ -1,5 +1,6 @@
 from django.db.models import get_model
 from django.http import HttpResponse
+from django.db.models.fields.related import ReverseManyRelatedObjectsDescriptor
 try:
     import json
 except ImportError:
@@ -11,7 +12,12 @@ from smart_selects.utils import (get_keywords, sort_results, serialize_results,
 
 def filterchain(request, app, model, field, value, manager=None):
     model_class = get_model(app, model)
-    keywords = get_keywords(field, value)
+
+    m2m = False
+    if isinstance(getattr(model_class, field), ReverseManyRelatedObjectsDescriptor):
+        m2m = True
+
+    keywords = get_keywords(field, value, m2m=m2m)
     queryset = get_queryset(model_class, manager)
 
     results = queryset.filter(**keywords)
@@ -28,7 +34,6 @@ def filterchain(request, app, model, field, value, manager=None):
 
 def filterchain_all(request, app, model, field, value):
     """Returns filtered results followed by excluded results below."""
-
     model_class = get_model(app, model)
     keywords = get_keywords(field, value)
     queryset = get_queryset(model_class)

--- a/smart_selects/widgets.py
+++ b/smart_selects/widgets.py
@@ -6,11 +6,12 @@ from django.conf import settings
 from django.contrib.admin.templatetags.admin_static import static
 from django.core.urlresolvers import reverse
 from django.db.models import get_model
-from django.forms.widgets import Select
+from django.forms.widgets import Select, SelectMultiple
 from django.utils.safestring import mark_safe
+from django.utils.html import escape
 
 from smart_selects.utils import unicode_sorter
-
+import json
 
 if django.VERSION >= (1, 2, 0) and getattr(settings,
                                            'USE_DJANGO_JQUERY', True):
@@ -20,7 +21,6 @@ else:
     JQUERY_URL = getattr(settings, 'JQUERY_URL', 'http://ajax.googleapis.com/ajax/libs/jquery/1.3.2/jquery.min.js')
 
 URL_PREFIX = getattr(settings, "SMART_SELECTS_URL_PREFIX", "")
-
 
 class ChainedSelect(Select):
     def __init__(self, app_name, model_name, chain_field,
@@ -52,6 +52,7 @@ class ChainedSelect(Select):
             chain_field = '-'.join(name.split('-')[:-1] + [self.chain_field])
         else:
             chain_field = self.chain_field
+
         if not self.view_name:
             if self.show_all:
                 view_name = "chained_filter_all"
@@ -120,6 +121,7 @@ class ChainedSelect(Select):
                         $('#%(id)s option:first').attr('selected', 'selected');
                         var auto_choose = %(auto_choose)s;
                         if(init_value){
+                            console.log(init_value);
                             $('#%(id)s option[value="'+ init_value +'"]').attr('selected', 'selected');
                         }
                         if(auto_choose && j.length == 1){
@@ -159,7 +161,7 @@ class ChainedSelect(Select):
                    "id": attrs['id'],
                    'value': value,
                    'auto_choose': auto_choose,
-                   'empty_label': empty_label}
+                   'empty_label': escape(empty_label)}
         final_choices = []
 
         if value:
@@ -197,5 +199,187 @@ class ChainedSelect(Select):
         else:
             final_attrs['class'] = 'chained'
         output = super(ChainedSelect, self).render(name, value, final_attrs, choices=final_choices)
+        output += js
+        return mark_safe(output)
+
+
+class ChainedSelectMultiple(SelectMultiple):
+    def __init__(self, app_name, model_name, chain_field,
+                 model_field, show_all, auto_choose,
+                 manager=None, view_name=None, *args, **kwargs):
+        self.app_name = app_name
+        self.model_name = model_name
+        self.chain_field = chain_field
+        self.model_field = model_field
+        self.show_all = show_all
+        self.auto_choose = auto_choose
+        self.manager = manager
+        self.view_name = view_name
+
+        super(SelectMultiple, self).__init__(*args, **kwargs)
+
+    class Media:
+        extra = '' if settings.DEBUG else '.min'
+        js = [
+            'jquery%s.js' % extra,
+            'jquery.init.js'
+        ]
+        if USE_DJANGO_JQUERY:
+            js = [static('admin/js/%s' % url) for url in js]
+        elif JQUERY_URL:
+            js = [JQUERY_URL]
+
+    def render(self, name, value, attrs=None, choices=()):
+        if len(name.split('-')) > 1:  # formset
+            chain_field = '-'.join(name.split('-')[:-1] + [self.chain_field])
+        else:
+            chain_field = self.chain_field
+
+        if not self.view_name:
+            if self.show_all:
+                view_name = "chained_filter_all"
+            else:
+                view_name = "chained_filter"
+        else:
+            view_name = self.view_name
+        kwargs = {'app': self.app_name, 'model': self.model_name,
+                  'field': self.model_field, 'value': "1"}
+        if self.manager is not None:
+            kwargs.update({'manager': self.manager})
+        url = URL_PREFIX + ("/".join(reverse(view_name, kwargs=kwargs).split("/")[:-2]))
+        if self.auto_choose:
+            auto_choose = 'true'
+        else:
+            auto_choose = 'false'
+        empty_label = ''
+        js = """
+        <script type="text/javascript">
+        //<![CDATA[
+        (function($) {
+            function fireEvent(element,event){
+                if (document.createEventObject){
+                // dispatch for IE
+                var evt = document.createEventObject();
+                return element.fireEvent('on'+event,evt)
+                }
+                else{
+                // dispatch for firefox + others
+                var evt = document.createEvent("HTMLEvents");
+                evt.initEvent(event, true, true ); // event type,bubbling,cancelable
+                return !element.dispatchEvent(evt);
+                }
+            }
+
+            function dismissRelatedLookupPopup(win, chosenId) {
+                var name = windowname_to_id(win.name);
+                var elem = document.getElementById(name);
+                if (elem.className.indexOf('vManyToManyRawIdAdminField') != -1 && elem.value) {
+                    elem.value += ',' + chosenId;
+                } else {
+                    elem.value = chosenId;
+                }
+                fireEvent(elem, 'change');
+                win.close();
+            }
+
+            $(document).ready(function(){
+                var initial_parent = $("#id_%(chainfield)s").val();
+                var initial_value = %(value)s;
+                function fill_field(val, init_value){
+        
+                    $.getJSON("%(url)s/"+val+"/", function(j){
+                        var options = '';
+
+                        for (var i = 0; i < j.length; i++) {
+                            options += '<option value="' + j[i].value + '">' + j[i].display + '<'+'/option>';
+                        }
+                        var width = $("#%(id)s").outerWidth();
+                        $("#%(id)s").html(options);
+                        if (navigator.appVersion.indexOf("MSIE") != -1)
+                            $("#%(id)s").width(width + 'px');
+                        var auto_choose = %(auto_choose)s;
+
+                        if(val == initial_parent){
+                            for (var i = 0; i < initial_value.length; i++) {
+                                $('#%(id)s option[value="'+ initial_value[i] +'"]').attr('selected', 'selected');
+                            }
+                        }
+                        console.log(auto_choose);
+                        console.log(j);
+                        if(auto_choose && j.length == 1){
+                            $('#%(id)s option[value="'+ j[0].value +'"]').attr('selected', 'selected');
+                        }
+
+                        $("#%(id)s").trigger('change');
+
+                        if ($.fn.chosen !== undefined) {
+                            $("#%(id)s").trigger('chosen:updated');
+                        }
+                    })
+                }
+
+                if(!$("#id_%(chainfield)s").hasClass("chained")){
+                    var val = $("#id_%(chainfield)s").val();
+                    fill_field(val, %(value)s);
+                }
+
+                $("#id_%(chainfield)s").change(function(){
+                    var start_value = $("#%(id)s").val();
+                    var val = $(this).val();
+                    fill_field(val, start_value);
+                })
+            })
+            if (typeof(dismissAddAnotherPopup) !== 'undefined') {
+                var oldDismissAddAnotherPopup = dismissAddAnotherPopup;
+                dismissAddAnotherPopup = function(win, newId, newRepr) {
+                    oldDismissAddAnotherPopup(win, newId, newRepr);
+                    if (windowname_to_id(win.name) == "id_%(chainfield)s") {
+                        $("#id_%(chainfield)s").change();
+                    }
+                }
+            }
+        })(jQuery || django.jQuery);
+        //]]>
+        </script>
+
+        """
+        js = js % {"chainfield": chain_field,
+                   "url": url,
+                   "id": attrs['id'],
+                   'value': json.dumps(value),
+                   'auto_choose': auto_choose}
+        final_choices = []
+
+        if value:
+            items = self.queryset.filter(pk__in=value)
+            try:  # maybe m2m?
+                pks = getattr(items, self.model_field).all().values_list('pk', flat=True)
+                filter = {self.model_field + "__in": pks}
+            except AttributeError:
+                try:  # maybe a set?
+                    pks = getattr(items, self.model_field + "_set").all().values_list('pk', flat=True)
+                    filter = {self.model_field + "__in": pks}
+                except:  # give up
+                    filter = {}
+            filtered = list(get_model(self.app_name, self.model_name).objects.filter(**filter).distinct())
+            filtered.sort(cmp=locale.strcoll, key=lambda x: unicode_sorter(unicode(x)))
+            for choice in filtered:
+                final_choices.append((choice.pk, unicode(choice)))
+        if len(final_choices) > 1:
+            final_choices = [("", (empty_label))] + final_choices
+        if self.show_all:
+            final_choices.append(("", (empty_label)))
+            self.choices = list(self.choices)
+            self.choices.sort(cmp=locale.strcoll, key=lambda x: unicode_sorter(x[1]))
+            for ch in self.choices:
+                if not ch in final_choices:
+                    final_choices.append(ch)
+        self.choices = ()
+        final_attrs = self.build_attrs(attrs, name=name)
+        if 'class' in final_attrs:
+            final_attrs['class'] += ' chained'
+        else:
+            final_attrs['class'] = 'chained'
+        output = super(ChainedSelectMultiple, self).render(name, value, final_attrs, choices=final_choices)
         output += js
         return mark_safe(output)


### PR DESCRIPTION
# ChainedManyToMany

## Status
There has been some requests -- for example #38 and #35 -- for the implementation support for a `ChainedManyToMany` field. This is an **imperfect attempt** at implementing a `ChainedManyToMany`. It works well, but I do not expect this PR to be merged in its current form because it still needs some cleanup. I am submitting it in it's current form because I believe this commit may be useful for anyone needing a `ChainedManyToMany` at the moment.

I will gladly appreciate any help in finishing the implementation. If you want to help, please look at the Known Issues, or just review and comment! :smile: 



## Usage
The `ChainedManyToMany` is to be used like the regular `ChainedForeignKey`. For example, if multiple countries were to be selected in the `README` example, the code could be changed to this:

```python
    countries = ChainedManyToManyField(
        Country,
        chained_field="continent",
        chained_model_field="countries",
    )
```
Value | Usage
------------ | -------------
`chained_field` | Field on same model this field should be chained to
`chained_model_field` | Field the values should be saved to (most probably the *through* field)

## Known issues
These issues *should be fixed* before this contribution is merged in the project
* Server side `ChainedManyToMany` clean is **disabled**. 
* This implementation is most probably suboptimal and should be cleaned. There is probably some code that still belongs to `ChainedForeignKey` in here.