### PR TITLE
allow spanning multiple relations (issue #93) [DO NOT MERGE]

### DIFF
--- a/smart_selects/urls.py
+++ b/smart_selects/urls.py
@@ -7,7 +7,7 @@ urlpatterns = patterns(
     'smart_selects.views',
     url(r'^all/(?P<app>[\w\-]+)/(?P<model>[\w\-]+)/(?P<field>[\w\-]+)/(?P<foreign_key_app_name>[\w\-]+)/(?P<foreign_key_model_name>[\w\-]+)/(?P<foreign_key_field_name>[\w\-]+)/(?P<value>[\w\-]+)/$',
         'filterchain_all', name='chained_filter_all'),
-    url(r'^filter/(?P<app>[\w\-]+)/(?P<model>[\w\-]+)/(?P<field>[\w\-]+)/(?P<foreign_key_app_name>[\w\-]+)/(?P<foreign_key_model_name>[\w\-]+)/(?P<foreign_key_field_name>[\w\-]+)/(?P<chain_field>[\w\-]+)/(?P<value>[\w\-]+)/$',
+    url(r'^filter/(?P<app>[\w\-]+)/(?P<model>[\w\-]+)/(?P<field>[\w\-]+)/(?P<foreign_key_app_name>[\w\-]+)/(?P<foreign_key_model_name>[\w\-]+)/(?P<foreign_key_field_name>[\w\-]+)/(?P<chain_field>[\w\-]+)/(?P<value>[\w\-]+)/(pk/(?P<pk>[\w\-]+)/)?$',
         'filterchain', name='chained_filter'),
     url(r'^filter/(?P<app>[\w\-]+)/(?P<model>[\w\-]+)/(?P<manager>[\w\-]+)/(?P<field>[\w\-]+)/(?P<foreign_key_app_name>[\w\-]+)/(?P<foreign_key_model_name>[\w\-]+)/(?P<foreign_key_field_name>[\w\-]+)/(?P<chain_field>[\w\-]+)/(?P<value>[\w\-]+)/$',
         'filterchain', name='chained_filter'),

--- a/smart_selects/urls.py
+++ b/smart_selects/urls.py
@@ -9,6 +9,6 @@ urlpatterns = patterns(
         'filterchain_all', name='chained_filter_all'),
     url(r'^filter/(?P<app>[\w\-]+)/(?P<model>[\w\-]+)/(?P<field>[\w\-]+)/(?P<foreign_key_app_name>[\w\-]+)/(?P<foreign_key_model_name>[\w\-]+)/(?P<foreign_key_field_name>[\w\-]+)/(?P<chain_field>[\w\-]+)/(?P<value>[\w\-]+)/(pk/(?P<pk>[\w\-]+)/)?$',
         'filterchain', name='chained_filter'),
-    url(r'^filter/(?P<app>[\w\-]+)/(?P<model>[\w\-]+)/(?P<manager>[\w\-]+)/(?P<field>[\w\-]+)/(?P<foreign_key_app_name>[\w\-]+)/(?P<foreign_key_model_name>[\w\-]+)/(?P<foreign_key_field_name>[\w\-]+)/(?P<chain_field>[\w\-]+)/(?P<value>[\w\-]+)/$',
+    url(r'^filter/(?P<app>[\w\-]+)/(?P<model>[\w\-]+)/(?P<manager>[\w\-]+)/(?P<field>[\w\-]+)/(?P<foreign_key_app_name>[\w\-]+)/(?P<foreign_key_model_name>[\w\-]+)/(?P<foreign_key_field_name>[\w\-]+)/(?P<chain_field>[\w\-]+)/(?P<value>[\w\-]+)/(pk/(?P<pk>[\w\-]+)/)?$',
         'filterchain', name='chained_filter'),
 )

--- a/smart_selects/urls.py
+++ b/smart_selects/urls.py
@@ -7,8 +7,8 @@ urlpatterns = patterns(
     'smart_selects.views',
     url(r'^all/(?P<app>[\w\-]+)/(?P<model>[\w\-]+)/(?P<field>[\w\-]+)/(?P<foreign_key_app_name>[\w\-]+)/(?P<foreign_key_model_name>[\w\-]+)/(?P<foreign_key_field_name>[\w\-]+)/(?P<value>[\w\-]+)/$',
         'filterchain_all', name='chained_filter_all'),
-    url(r'^filter/(?P<app>[\w\-]+)/(?P<model>[\w\-]+)/(?P<field>[\w\-]+)/(?P<foreign_key_app_name>[\w\-]+)/(?P<foreign_key_model_name>[\w\-]+)/(?P<foreign_key_field_name>[\w\-]+)/(?P<value>[\w\-]+)/$',
+    url(r'^filter/(?P<app>[\w\-]+)/(?P<model>[\w\-]+)/(?P<field>[\w\-]+)/(?P<foreign_key_app_name>[\w\-]+)/(?P<foreign_key_model_name>[\w\-]+)/(?P<foreign_key_field_name>[\w\-]+)/(?P<chain_field>[\w\-]+)/(?P<value>[\w\-]+)/$',
         'filterchain', name='chained_filter'),
-    url(r'^filter/(?P<app>[\w\-]+)/(?P<model>[\w\-]+)/(?P<manager>[\w\-]+)/(?P<field>[\w\-]+)/(?P<foreign_key_app_name>[\w\-]+)/(?P<foreign_key_model_name>[\w\-]+)/(?P<foreign_key_field_name>[\w\-]+)/(?P<value>[\w\-]+)/$',
+    url(r'^filter/(?P<app>[\w\-]+)/(?P<model>[\w\-]+)/(?P<manager>[\w\-]+)/(?P<field>[\w\-]+)/(?P<foreign_key_app_name>[\w\-]+)/(?P<foreign_key_model_name>[\w\-]+)/(?P<foreign_key_field_name>[\w\-]+)/(?P<chain_field>[\w\-]+)/(?P<value>[\w\-]+)/$',
         'filterchain', name='chained_filter'),
 )

--- a/smart_selects/views.py
+++ b/smart_selects/views.py
@@ -16,14 +16,18 @@ from smart_selects.utils import (get_keywords, sort_results, serialize_results,
 
 
 def filterchain(request, app, model, field, foreign_key_app_name, foreign_key_model_name,
-                foreign_key_field_name, value, chain_field, manager=None):
+                foreign_key_field_name, value, chain_field, manager=None, pk=None):
     
     chain_field = chain_field.split("__")
     chain_field.reverse()
 
     fk_model = get_model(foreign_key_app_name, foreign_key_model_name)
-    f = fk_model._meta.get_field_by_name(chain_field.pop())[0]
-    obj = f.rel.to.objects.get(pk = value)
+    if pk:
+	obj = fk_model.objects.get(pk = pk)
+	obj = getattr(obj, chain_field.pop())
+    else:
+        f = fk_model._meta.get_field_by_name(chain_field.pop())[0]
+        obj = f.rel.to.objects.get(pk = value)
     while len(chain_field):
 	obj = getattr(obj, chain_field.pop())
     value = obj.pk

--- a/smart_selects/widgets.py
+++ b/smart_selects/widgets.py
@@ -131,14 +131,15 @@ class ChainedSelect(Select):
                     }
                     $.getJSON("%(url)s/"+val+"/", function(j){
                         var options = '<option value="">%(empty_label)s<'+'/option>';
-                        var prev_value = $("#%(id)s").children("option[selected='selected']").val();
+                        var el = $("#%(id)s");
+                        var prev_value = el.children("option[selected='selected']").val();
                         for (var i = 0; i < j.length; i++) {
                             options += '<option value="' + j[i].value + '">' + j[i].display + '<'+'/option>';
                         }
-                        var width = $("#%(id)s").outerWidth();
-                        $("#%(id)s").html(options);
+                        var width = el.outerWidth();
+                        el.html(options);
                         if (navigator.appVersion.indexOf("MSIE") != -1)
-                            $("#%(id)s").width(width + 'px');
+                            el.width(width + 'px');
                         $('#%(id)s option:first').attr('selected', 'selected');
                         var auto_choose = %(auto_choose)s;
                         if(init_value){
@@ -148,7 +149,7 @@ class ChainedSelect(Select):
                             $('#%(id)s option[value="'+ j[0].value +'"]').attr('selected', 'selected');
                         }
                         if (init_value != prev_value)
-                            $("#%(id)s").trigger('change');
+                            el.trigger('change');
                     })
                 }
 

--- a/smart_selects/widgets.py
+++ b/smart_selects/widgets.py
@@ -153,13 +153,14 @@ class ChainedSelect(Select):
                     })
                 }
 
-                if(!$("#id_%(chainfield)s").hasClass("chained")){
-                    var val = $("#id_%(chainfield)s").val();
-                    fill_field(val, "%(value)s");
+                var chainfield = $("#id_%(chainfield)s");
+
+                if(!chainfield.hasClass("chained")){
+                    fill_field(chainfield.val(), "%(value)s");
                 }
 
-                $("#id_%(chainfield)s").change(function(){
-                    var start_value = $("#%(id)s").val();
+                chainfield.change(function(){
+                    var start_value = el.val();
                     var val = $(this).val();
                     fill_field(val, start_value);
                 })

--- a/smart_selects/widgets.py
+++ b/smart_selects/widgets.py
@@ -75,6 +75,7 @@ class ChainedSelect(Select):
             'foreign_key_app_name': self.foreign_key_app_name,
             'foreign_key_model_name': self.foreign_key_model_name,
             'foreign_key_field_name': self.foreign_key_field_name,
+            'chain_field': self.chain_field,
             'value': '1'
             }
         if self.manager is not None:
@@ -174,7 +175,7 @@ class ChainedSelect(Select):
         </script>
 
         """
-        js = js % {"chainfield": chain_field,
+        js = js % {"chainfield": chain_field.split("__")[0],
                    "url": url,
                    "id": attrs['id'],
                    'value': value,

--- a/smart_selects/widgets.py
+++ b/smart_selects/widgets.py
@@ -160,7 +160,7 @@ class ChainedSelect(Select):
 
                 var chainfield = $("#id_%(chainfield)s");
 
-                if(!chainfield.hasClass("chained")){
+                if(!chainfield.hasClass("chained") || !el.children().length){
                     var pk;
                     var val = chainfield.val();
                     if (!chainfield.length) {

--- a/smart_selects/widgets.py
+++ b/smart_selects/widgets.py
@@ -130,6 +130,7 @@ class ChainedSelect(Select):
                         $("#%(id)s").trigger('change');
                         return;
                     }
+                    if (init_value == "None") init_value = undefined;
                     var url = "%(url)s/";
                     if (!val && pk)
                         url += "0/pk/"+pk;

--- a/smart_selects/widgets.py
+++ b/smart_selects/widgets.py
@@ -122,15 +122,20 @@ class ChainedSelect(Select):
 
             $(document).ready(function(){
                 var el = $("#%(id)s");
-                function fill_field(val, init_value){
-                    if (!val || val==''){
+                function fill_field(val, init_value, pk){
+                    if ((!val || val=='') && !pk){
                         options = '<option value="">%(empty_label)s<'+'/option>';
                         $("#%(id)s").html(options);
                         $('#%(id)s option:first').attr('selected', 'selected');
                         $("#%(id)s").trigger('change');
                         return;
                     }
-                    $.getJSON("%(url)s/"+val+"/", function(j){
+                    var url = "%(url)s/";
+                    if (!val && pk)
+                        url += "0/pk/"+pk;
+                    else
+                        url += val;
+                    $.getJSON(url+"/", function(j){
                         var options = '<option value="">%(empty_label)s<'+'/option>';
                         var prev_value = el.children("option[selected='selected']").val();
                         for (var i = 0; i < j.length; i++) {
@@ -156,7 +161,20 @@ class ChainedSelect(Select):
                 var chainfield = $("#id_%(chainfield)s");
 
                 if(!chainfield.hasClass("chained")){
-                    fill_field(chainfield.val(), "%(value)s");
+                    var pk;
+                    var val = chainfield.val();
+                    if (!chainfield.length) {
+                        var a;
+                        a = el.parents("tr").first().children("td.action-checkbox").children("input.action-select");
+                        if (a.length)
+                            pk = a.val();
+                        else {
+                            a = el.parents("div.inline-group");
+                            if (a.length)
+                                val = document.location.pathname.match(/\d+[/]?$/)[0].replace("/","");
+                        }
+                    }
+                    fill_field(val, "%(value)s", pk);
                 }
 
                 chainfield.change(function(){

--- a/smart_selects/widgets.py
+++ b/smart_selects/widgets.py
@@ -131,6 +131,7 @@ class ChainedSelect(Select):
                     }
                     $.getJSON("%(url)s/"+val+"/", function(j){
                         var options = '<option value="">%(empty_label)s<'+'/option>';
+                        var prev_value = $("#%(id)s").children("option[selected='selected']").val();
                         for (var i = 0; i < j.length; i++) {
                             options += '<option value="' + j[i].value + '">' + j[i].display + '<'+'/option>';
                         }
@@ -146,7 +147,8 @@ class ChainedSelect(Select):
                         if(auto_choose && j.length == 1){
                             $('#%(id)s option[value="'+ j[0].value +'"]').attr('selected', 'selected');
                         }
-                        $("#%(id)s").trigger('change');
+                        if (init_value != prev_value)
+                            $("#%(id)s").trigger('change');
                     })
                 }
 

--- a/smart_selects/widgets.py
+++ b/smart_selects/widgets.py
@@ -121,6 +121,7 @@ class ChainedSelect(Select):
             }
 
             $(document).ready(function(){
+                var el = $("#%(id)s");
                 function fill_field(val, init_value){
                     if (!val || val==''){
                         options = '<option value="">%(empty_label)s<'+'/option>';
@@ -131,7 +132,6 @@ class ChainedSelect(Select):
                     }
                     $.getJSON("%(url)s/"+val+"/", function(j){
                         var options = '<option value="">%(empty_label)s<'+'/option>';
-                        var el = $("#%(id)s");
                         var prev_value = el.children("option[selected='selected']").val();
                         for (var i = 0; i < j.length; i++) {
                             options += '<option value="' + j[i].value + '">' + j[i].display + '<'+'/option>';


### PR DESCRIPTION
it's rough and incomplete so I put it here more for discussion than merging
- allows only forward foreign keys for chained_field right now
- since it's using native django filter syntax for chained_model_field,
  it probably works via any relations

``` python
class BaseModel(Model):
    def __unicode__(self):
        return u"%s %d" % (self._meta.model_name, self.id)

    class Meta:
        ordering = ("id", )
        abstract = True

class A(BaseModel):
    pass

class B(BaseModel):
    a = ForeignKey(A)

class C(BaseModel):
    a = ForeignKey(A)

class D(BaseModel):
    c = ForeignKey(C)

class Main(BaseModel):
    b = ForeignKey(B)
    d = ChainedForeignKey(D, chained_field = "b__a", chained_model_field = "c__a")
```

Edit (by blag): Formatted with GFM.
