### PR TITLE
Fix double selected option when initial_value set

### DIFF
--- a/smart_selects/widgets.py
+++ b/smart_selects/widgets.py
@@ -137,10 +137,11 @@ class ChainedSelect(Select):
                         $("#%(id)s").html(options);
                         if (navigator.appVersion.indexOf("MSIE") != -1)
                             $("#%(id)s").width(width + 'px');
-                        $('#%(id)s option:first').attr('selected', 'selected');
                         var auto_choose = %(auto_choose)s;
                         if(init_value){
                             $('#%(id)s option[value="'+ init_value +'"]').attr('selected', 'selected');
+                        } else {
+                            $('#%(id)s option:first').attr('selected', 'selected');
                         }
                         if(auto_choose && j.length == 1){
                             $('#%(id)s option[value="'+ j[0].value +'"]').attr('selected', 'selected');

--- a/smart_selects/widgets.py
+++ b/smart_selects/widgets.py
@@ -140,12 +140,13 @@ class ChainedSelect(Select):
                         var auto_choose = %(auto_choose)s;
                         if(init_value){
                             $('#%(id)s option[value="'+ init_value +'"]').attr('selected', 'selected');
-                        } else {
-                            $('#%(id)s option:first').attr('selected', 'selected');
                         }
                         if(auto_choose && j.length == 1){
                             $('#%(id)s option[value="'+ j[0].value +'"]').attr('selected', 'selected');
+                        } else if ( $('#%(id)s option[selected=selected]').length === 0 ) {
+                            $('#%(id)s option:first').attr('selected', 'selected');
                         }
+
                         $("#%(id)s").trigger('change');
                     })
                 }


### PR DESCRIPTION
By default smart selects will always set the selected attribute to the first item on the options list. This causes some problems when trying to figure out which was the selected value during load because even if a initial value was set, the first item is selected too.
