### PR TITLE
Moved JS code to an external final supports dynamic inlines

### DIFF
--- a/smart_selects/static/smart_selects/js/chained.js
+++ b/smart_selects/static/smart_selects/js/chained.js
@@ -62,9 +62,27 @@
 
         $("#content-main").on('change', 'select', function(){
             var relatedTo = $(this);
-            var relatedSelect = $('select.chained[data-ss-id="'+relatedTo.attr('id')+'"]');
+            // If a new inline was added, replace the prefix correctly
+            var chainedSelect = $('select.chained:visible');
+            chainedSelect.not('.chained-prefixed').each(function() {
+                var $this = $(this);
+                if ($this.data('ss-id').indexOf('__prefix__') !== -1) {
+                    var row = $this.attr('id').match(/-[0-9]+-/);
+                    var new_ss_id = $this.data('ss-id').replace('-__prefix__-', row[0]);
+                    $this.attr('data-ss-id', new_ss_id);
+                }
+                $this.addClass('chained-prefixed');
+            });
+            var relatedSelect = chainedSelect.filter('[data-ss-id="'+relatedTo.attr('id')+'"]');
             if ( relatedSelect.length == 0 ) return;
             fill_field(relatedTo, relatedSelect);
+        });
+        // Load available options from related select when no value is set
+        $('select[data-ss-id]').each(function() {
+            var $this = $(this);
+            var value = $this.val();
+            if (!value)
+                $('#'+$this.attr('data-ss-id')).change();
         });
     });
     if (typeof(dismissAddAnotherPopup) !== 'undefined') {

--- a/smart_selects/static/smart_selects/js/chained.js
+++ b/smart_selects/static/smart_selects/js/chained.js
@@ -1,0 +1,81 @@
+(function($) {
+    function fireEvent(element,event){
+        if (document.createEventObject){
+            // dispatch for IE
+            var evt = document.createEventObject();
+            return element.fireEvent('on'+event,evt)
+        }
+        else{
+            // dispatch for firefox + others
+            var evt = document.createEvent("HTMLEvents");
+            evt.initEvent(event, true, true ); // event type,bubbling,cancelable
+            return !element.dispatchEvent(evt);
+        }
+    }
+
+    function dismissRelatedLookupPopup(win, chosenId) {
+        var name = windowname_to_id(win.name);
+        var elem = document.getElementById(name);
+        if (elem.className.indexOf('vManyToManyRawIdAdminField') != -1 && elem.value) {
+            elem.value += ',' + chosenId;
+        } else {
+            elem.value = chosenId;
+        }
+        fireEvent(elem, 'change');
+        win.close();
+    }
+
+    $(document).ready(function(){
+        function fill_field(relatedTo, relatedSelect) {
+            var init_value = relatedSelect.val();
+            var val = relatedTo.val();
+            var empty_label = relatedSelect.data('ss-empty_label');
+            if (!val || val==''){
+                options = '<option value="">'+empty_label+'<'+'/option>';
+                relatedSelect.html(options);
+                relatedSelect.find('option:first').attr('selected', 'selected');
+                relatedSelect.trigger('change');
+                return;
+            }
+
+            $.getJSON(relatedSelect.data('ss-url') + "/"+val+"/", function(j){
+                var options = '<option value="">'+empty_label+'<'+'/option>';
+                for (var i = 0; i < j.length; i++) {
+                    options += '<option value="' + j[i].value + '">' + j[i].display + '<'+'/option>';
+                }
+                var width = relatedSelect.outerWidth();
+                relatedSelect.html(options);
+                if (navigator.appVersion.indexOf("MSIE") != -1)
+                    relatedSelect.width(width + 'px');
+                var auto_choose = relatedSelect.data('ss-auto_choose');
+                if(init_value){
+                    relatedSelect.find('option[value="'+ init_value +'"]').attr('selected', 'selected');
+                }
+                if(auto_choose && j.length == 1){
+                    relatedSelect.find('option[value="'+ j[0].value +'"]').attr('selected', 'selected');
+                } else if (relatedSelect.find('option[selected=selected]').length === 0) {
+                    relatedSelect.find('option:first').attr('selected', 'selected');
+                }
+                relatedSelect.trigger('change');
+            });
+        }
+
+        $("#content-main").on('change', 'select', function(){
+            var relatedTo = $(this);
+            var relatedSelect = $('select.chained[data-ss-id="'+relatedTo.attr('id')+'"]');
+            if ( relatedSelect.length == 0 ) return;
+            fill_field(relatedTo, relatedSelect);
+        });
+    });
+    if (typeof(dismissAddAnotherPopup) !== 'undefined') {
+        var oldDismissAddAnotherPopup = dismissAddAnotherPopup;
+        dismissAddAnotherPopup = function(win, newId, newRepr) {
+            oldDismissAddAnotherPopup(win, newId, newRepr);
+            var id = windowname_to_id(win.name);
+            var relatedSelect = $('select.chained[data-ss-id="'+id+'"]');
+            if ( relatedSelect.length == 0 ) return;
+            $('#' + id).change();
+        }
+    }
+})(jQuery || django.jQuery);
+

--- a/smart_selects/widgets.py
+++ b/smart_selects/widgets.py
@@ -101,8 +101,7 @@ class ChainedSelect(Select):
             available_choices = self._get_available_choices(self.queryset, value)
             for choice in available_choices:
                 final_choices.append((choice.pk, force_text(choice)))
-        if len(final_choices) > 1:
-            final_choices = [("", (empty_label))] + final_choices
+        final_choices = [("", (empty_label))] + final_choices
         if self.show_all:
             final_choices.append(("", (empty_label)))
             self.choices = list(self.choices)


### PR DESCRIPTION
Instead of initializing each field we add attributes to the select items
and use that to initialize all of them later with a global script.
We bind the change even to '#content-main select' so we can handle
dynamic items added later (inlines).
