### PR TITLE
fix display issue with grappelli

### DIFF
--- a/smart_selects/widgets.py
+++ b/smart_selects/widgets.py
@@ -200,9 +200,10 @@ class ChainedSelect(Select):
             final_attrs['class'] += ' chained'
         else:
             final_attrs['class'] = 'chained'
-
-        output = super(ChainedSelect, self).render(name, value, final_attrs, choices=final_choices)
-        output += js
+        
+        output = js
+        output += super(ChainedSelect, self).render(name, value, final_attrs, choices=final_choices)
+        
         return mark_safe(output)
 
     def _get_available_choices(self, queryset, value):


### PR DESCRIPTION
Hi,

When using smart-selects with grappelli, a bug makes the select unclickable : https://groups.google.com/forum/#!topic/django-grappelli/BO6kw_gsryQ (tested under chrome and edge, django 1.8.2 and grappelli 2.7.1 ).

It seems the bug comes from the position of the javascript block, which is between the select and the add button. It's a bit odd, since a javascript block shouldn't have impact with other elements...

Putting the javascript block before the select seems to fix the problem.

To test (or if in a hurry) : `sudo pip3 install -e git+https://github.com/olivierdalang/django-smart-selects.git@fix-grappelli-dom-bug#egg=django-smart-selects`

Best,

Olivier