### PR TITLE
Fix widget media

### DIFF
--- a/smart_selects/widgets.py
+++ b/smart_selects/widgets.py
@@ -26,7 +26,35 @@ else:
 URL_PREFIX = getattr(settings, "SMART_SELECTS_URL_PREFIX", "")
 
 
-class ChainedSelect(Select):
+class JqueryMediaMixin(object):
+    @property
+    def media(self):
+        """Media defined as a dynamic property instead of an inner class."""
+        media = super(JqueryMediaMixin, self).media
+
+        js = []
+
+        if JQUERY_URL:
+            js.append(JQUERY_URL)
+        else:
+            vendor = '' if django.VERSION < (1, 9, 0) else 'vendor/jquery/'
+            extra = '' if settings.DEBUG else '.min'
+
+            jquery_paths = [
+                '{}jquery{}.js'.format(vendor, extra),
+                'jquery.init.js',
+            ]
+
+            if USE_DJANGO_JQUERY:
+                jquery_paths = ['admin/js/{}'.format(path) for path in jquery_paths]
+
+            js.extend(jquery_paths)
+
+        media.add_js(js)
+        return media
+
+
+class ChainedSelect(JqueryMediaMixin, Select):
     def __init__(self, to_app_name, to_model_name, chained_field, chained_model_field,
                  foreign_key_app_name, foreign_key_model_name, foreign_key_field_name,
                  show_all, auto_choose, manager=None, view_name=None, *args, **kwargs):
@@ -48,26 +76,7 @@ class ChainedSelect(Select):
         """Media defined as a dynamic property instead of an inner class."""
         media = super(ChainedSelect, self).media
 
-        js = ['smart-selects/admin/js/chainedfk.js']
-
-        if JQUERY_URL:
-            js.append(JQUERY_URL)
-        else:
-            vendor = '' if django.VERSION < (1, 9, 0) else 'vendor/jquery/'
-            extra = '' if settings.DEBUG else '.min'
-
-            jquery_paths = [
-                '{}jquery{}.js'.format(vendor, extra),
-                'jquery.init.js',
-            ]
-
-            if USE_DJANGO_JQUERY:
-                jquery_paths = ['admin/js/{}'.format(path) for path in jquery_paths]
-
-            js.extend(jquery_paths)
-
-        media.add_js(js)
-
+        media.add_js(['smart-selects/admin/js/chainedfk.js'])
         return media
 
     def render(self, name, value, attrs=None, choices=()):
@@ -183,7 +192,7 @@ class ChainedSelect(Select):
         return filtered
 
 
-class ChainedSelectMultiple(SelectMultiple):
+class ChainedSelectMultiple(JqueryMediaMixin, SelectMultiple):
     def __init__(self, to_app_name, to_model_name, chain_field, chained_model_field,
                  foreign_key_app_name, foreign_key_model_name, foreign_key_field_name,
                  auto_choose, manager=None, *args, **kwargs):
@@ -204,26 +213,7 @@ class ChainedSelectMultiple(SelectMultiple):
         """Media defined as a dynamic property instead of an inner class."""
         media = super(ChainedSelectMultiple, self).media
 
-        js = ['smart-selects/admin/js/chainedm2m.js']
-
-        if JQUERY_URL:
-            js.append(JQUERY_URL)
-        else:
-            vendor = '' if django.VERSION < (1, 9, 0) else 'vendor/jquery/'
-            extra = '' if settings.DEBUG else '.min'
-
-            jquery_paths = [
-                '{}jquery{}.js'.format(vendor, extra),
-                'jquery.init.js',
-            ]
-
-            if USE_DJANGO_JQUERY:
-                jquery_paths = ['admin/js/{}'.format(path) for path in jquery_paths]
-
-            js.extend(jquery_paths)
-
-        media.add_js(js)
-
+        media.add_js(['smart-selects/admin/js/chainedm2m.js'])
         return media
 
     def render(self, name, value, attrs=None, choices=()):

--- a/smart_selects/widgets.py
+++ b/smart_selects/widgets.py
@@ -1,10 +1,8 @@
 import django
 
 from django.conf import settings
-from django.contrib.admin.templatetags.admin_static import static
 from django.core.urlresolvers import reverse
 from django.forms.widgets import Select, SelectMultiple
-from django import forms
 from django.utils.safestring import mark_safe
 from django.utils.encoding import force_text
 from django.utils.html import escape
@@ -20,6 +18,7 @@ except ImportError:
 
 if django.VERSION >= (1, 2, 0) and getattr(settings, 'USE_DJANGO_JQUERY', True):
     USE_DJANGO_JQUERY = True
+    JQUERY_URL = None
 else:
     USE_DJANGO_JQUERY = False
     JQUERY_URL = getattr(settings, 'JQUERY_URL', 'https://ajax.googleapis.com/ajax/libs/jquery/2.2.0/jquery.min.js')
@@ -47,19 +46,29 @@ class ChainedSelect(Select):
     @property
     def media(self):
         """Media defined as a dynamic property instead of an inner class."""
-        vendor = '' if django.VERSION < (1, 9, 0) else 'vendor/jquery/'
-        extra = '' if settings.DEBUG else '.min'
-        js = [
-            '%sjquery%s.js' % (vendor, extra),
-            'jquery.init.js',
-        ]
-        if USE_DJANGO_JQUERY:
-            js = [static('admin/js/%s' % url) for url in js]
-        elif JQUERY_URL:
-            js = [JQUERY_URL]
-        js = js + [static('smart-selects/admin/js/chainedfk.js')]
+        media = super(ChainedSelect, self).media
 
-        return forms.Media(js=js)
+        js = ['smart-selects/admin/js/chainedfk.js']
+
+        if JQUERY_URL:
+            js.append(JQUERY_URL)
+        else:
+            vendor = '' if django.VERSION < (1, 9, 0) else 'vendor/jquery/'
+            extra = '' if settings.DEBUG else '.min'
+
+            jquery_paths = [
+                '{}jquery{}.js'.format(vendor, extra),
+                'jquery.init.js',
+            ]
+
+            if USE_DJANGO_JQUERY:
+                jquery_paths = ['admin/js/{}'.format(path) for path in jquery_paths]
+
+            js.extend(jquery_paths)
+
+        media.add_js(js)
+
+        return media
 
     def render(self, name, value, attrs=None, choices=()):
         if len(name.split('-')) > 1:  # formset
@@ -140,10 +149,10 @@ class ChainedSelect(Select):
             final_attrs['class'] += ' chained'
         else:
             final_attrs['class'] = 'chained'
-        
+
         output = js
         output += super(ChainedSelect, self).render(name, value, final_attrs, choices=final_choices)
-        
+
         return mark_safe(output)
 
     def _get_available_choices(self, queryset, value):
@@ -193,19 +202,29 @@ class ChainedSelectMultiple(SelectMultiple):
     @property
     def media(self):
         """Media defined as a dynamic property instead of an inner class."""
-        vendor = '' if django.VERSION < (1, 9, 0) else 'vendor/jquery/'
-        extra = '' if settings.DEBUG else '.min'
-        js = [
-            '%sjquery%s.js' % (vendor, extra),
-            'jquery.init.js',
-        ]
-        if USE_DJANGO_JQUERY:
-            js = [static('admin/js/%s' % url) for url in js]
-        elif JQUERY_URL:
-            js = [JQUERY_URL]
-        js = js + [static('smart-selects/admin/js/chainedm2m.js')]
+        media = super(ChainedSelectMultiple, self).media
 
-        return forms.Media(js=js)
+        js = ['smart-selects/admin/js/chainedm2m.js']
+
+        if JQUERY_URL:
+            js.append(JQUERY_URL)
+        else:
+            vendor = '' if django.VERSION < (1, 9, 0) else 'vendor/jquery/'
+            extra = '' if settings.DEBUG else '.min'
+
+            jquery_paths = [
+                '{}jquery{}.js'.format(vendor, extra),
+                'jquery.init.js',
+            ]
+
+            if USE_DJANGO_JQUERY:
+                jquery_paths = ['admin/js/{}'.format(path) for path in jquery_paths]
+
+            js.extend(jquery_paths)
+
+        media.add_js(js)
+
+        return media
 
     def render(self, name, value, attrs=None, choices=()):
         if len(name.split('-')) > 1:  # formset


### PR DESCRIPTION
Using the `static` function here is problematic.

After upgrading smart-selects I found that I couldn't deploy as every time I tried to run collectstatic, django admin would try to import smart-selects widgets, which would try to load `chainedm2m.js`, which would fail because they hadn't been static collected yet.. you can see the problem!

Just using the path strings avoids this problem.

Relevant traceback: https://gist.github.com/johtso/625d33d7fb33f6132d898abbd8cda40f