### PR TITLE
Add support for Chained M2M when parent is a ManyToManyField.

### DIFF
--- a/smart_selects/static/smart-selects/admin/js/chainedm2m.js
+++ b/smart_selects/static/smart-selects/admin/js/chainedm2m.js
@@ -45,7 +45,8 @@
                     if (navigator.appVersion.indexOf("MSIE") != -1)
                         $(elem_id).width(width + 'px');
 
-                    if(val == initial_parent){
+                    // if val and initial_parent have any common values, we need to set selected options.
+                    if($(val).filter(initial_parent).length > 0) {
                         for (var i = 0; i < initial_value.length; i++) {
                             $(elem_id + ' option[value="'+ initial_value[i] +'"]').attr('selected', 'selected');
                         }

--- a/smart_selects/urls.py
+++ b/smart_selects/urls.py
@@ -5,10 +5,10 @@ except ImportError:
     from django.conf.urls import url
 
 urlpatterns = [
-    url(r'^all/(?P<app>[\w\-]+)/(?P<model>[\w\-]+)/(?P<field>[\w\-]+)/(?P<foreign_key_app_name>[\w\-]+)/(?P<foreign_key_model_name>[\w\-]+)/(?P<foreign_key_field_name>[\w\-]+)/(?P<value>[\w\-]+)/$',
+    url(r'^all/(?P<app>[\w\-]+)/(?P<model>[\w\-]+)/(?P<field>[\w\-]+)/(?P<foreign_key_app_name>[\w\-]+)/(?P<foreign_key_model_name>[\w\-]+)/(?P<foreign_key_field_name>[\w\-]+)/(?P<value>[\w\-,]+)/$',
         views.filterchain_all, name='chained_filter_all'),
-    url(r'^filter/(?P<app>[\w\-]+)/(?P<model>[\w\-]+)/(?P<field>[\w\-]+)/(?P<foreign_key_app_name>[\w\-]+)/(?P<foreign_key_model_name>[\w\-]+)/(?P<foreign_key_field_name>[\w\-]+)/(?P<value>[\w\-]+)/$',
+    url(r'^filter/(?P<app>[\w\-]+)/(?P<model>[\w\-]+)/(?P<field>[\w\-]+)/(?P<foreign_key_app_name>[\w\-]+)/(?P<foreign_key_model_name>[\w\-]+)/(?P<foreign_key_field_name>[\w\-]+)/(?P<value>[\w\-,]+)/$',
         views.filterchain, name='chained_filter'),
-    url(r'^filter/(?P<app>[\w\-]+)/(?P<model>[\w\-]+)/(?P<manager>[\w\-]+)/(?P<field>[\w\-]+)/(?P<foreign_key_app_name>[\w\-]+)/(?P<foreign_key_model_name>[\w\-]+)/(?P<foreign_key_field_name>[\w\-]+)/(?P<value>[\w\-]+)/$',
+    url(r'^filter/(?P<app>[\w\-]+)/(?P<model>[\w\-]+)/(?P<manager>[\w\-]+)/(?P<field>[\w\-]+)/(?P<foreign_key_app_name>[\w\-]+)/(?P<foreign_key_model_name>[\w\-]+)/(?P<foreign_key_field_name>[\w\-]+)/(?P<value>[\w\-,]+)/$',
         views.filterchain, name='chained_filter'),
 ]

--- a/smart_selects/views.py
+++ b/smart_selects/views.py
@@ -1,5 +1,6 @@
 from django.http import HttpResponse
 from django.db.models import Q
+from django.utils.six import iteritems
 
 try:
     from django.apps import apps
@@ -41,7 +42,7 @@ def do_filter(qs, keywords, exclude=False):
     Support for multiple-selected parent values.
     """
     and_q = Q()
-    for keyword, value in keywords.iteritems():
+    for keyword, value in iteritems(keywords):
         values = value.split(",")
         if len(values) > 0:
             or_q = Q()


### PR DESCRIPTION
The current codebase does not appear to support ChainedManyToManyField when the parent chained field is itself a ManyToManyField.  This results in selected values not appearing in the admin.  This patch adds support for this case.