### PR TITLE
Fixed bug - duplication of jquery imports.

### DIFF
--- a/smart_selects/widgets.py
+++ b/smart_selects/widgets.py
@@ -46,7 +46,7 @@ class JqueryMediaMixin(object):
             ]
 
             if USE_DJANGO_JQUERY:
-                jquery_paths = ['admin/js/{}'.format(path) for path in jquery_paths]
+                jquery_paths = ['{}admin/js/{}'.format(settings.STATIC_URL, path) for path in jquery_paths]
 
             js.extend(jquery_paths)
 


### PR DESCRIPTION
The problem is that jquery.js imports get duplicated which causes errors.
Here https://github.com/django/django/blob/master/django/forms/widgets.py#L94 jquery links appear as /static/admin/js/jquery.js but in django-smart-selects it appears as admin/js/jquery.js, I changed it to use the static path so that it would not get duplicated.
