### PR TITLE
fix error with global options for all selects

### DIFF
--- a/smart_selects/static/smart-selects/admin/js/chainedm2m.js
+++ b/smart_selects/static/smart-selects/admin/js/chainedm2m.js
@@ -53,7 +53,7 @@
                 val = [].concat(val);
                 initial_parent = [].concat(initial_parent);
 
-                var target_url = url + "/" + val + "/";
+                var target_url = url + "/" + val + "/",
                     options = [],
                     selectedoptions = [];
 


### PR DESCRIPTION
I found an error when m2m fields works incorrect. All options added in one select. 

![default](https://cloud.githubusercontent.com/assets/18362928/24297191/ab1b417c-10c3-11e7-90cb-207e0889cd0b.png)
