### PR TITLE
build_attrs signature changed in django 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ language: python
 env:
   - DJANGO_VERSION="Django>=1.8,<1.9"
   - DJANGO_VERSION="Django>=1.9,<1.10"
-  - DJANGO_VERSION="Django>=1.10,<2.0"
+  - DJANGO_VERSION="Django>=1.10,<1.11"
+  - DJANGO_VERSION="Django>=1.11,<2.0"
   - DJANGO_VERSION='https://github.com/django/django/archive/master.tar.gz'
 python:
   - "2.7"

--- a/smart_selects/widgets.py
+++ b/smart_selects/widgets.py
@@ -157,7 +157,12 @@ class ChainedSelect(JqueryMediaMixin, Select):
                     final_choices.append(ch)
         self.choices = final_choices
 
-        final_attrs = self.build_attrs(attrs, name=name)
+        try:
+            final_attrs = self.build_attrs(attrs, name=name)
+        except TypeError:
+            # Django >= 1.11
+            final_attrs = self.build_attrs(attrs, {'name': name})
+
         if 'class' in final_attrs:
             final_attrs['class'] += ' chained'
         else:


### PR DESCRIPTION
This should fix `build_attrs() got an unexpected keyword argument 'name'` since the [build_attrs signature changed](https://github.com/django/django/blob/1.11/django/forms/widgets.py#L228) and give support for the new Django 1.11