### PR TITLE
WIP: Externalize field binding

### DIFF
--- a/smart_selects/static/smart-selects/admin/js/bindfields.js
+++ b/smart_selects/static/smart-selects/admin/js/bindfields.js
@@ -5,7 +5,7 @@
         var chainfield = "#id_" + $(item).attr("data-chainfield");
         var url = $(item).attr("data-url");
         var id = "#" + $(item).attr("id");
-        var value = $(item).attr("data-value");
+        var value = JSON.parse($(item).attr("data-value"));
         var auto_choose = $(item).attr("data-auto_choose");
         if($(item).hasClass("chained-fk")) {
             var empty_label = $(item).attr("data-empty_label");

--- a/smart_selects/static/smart-selects/admin/js/bindfields.js
+++ b/smart_selects/static/smart-selects/admin/js/bindfields.js
@@ -1,0 +1,53 @@
+(function($) {
+    "use strict";
+
+    function initItem(item) {
+        var chainfield = "#id_" + $(item).attr("data-chainfield");
+        var url = $(item).attr("data-url");
+        var id = "#" + $(item).attr("id");
+        var value = $(item).attr("data-value");
+        var auto_choose = $(item).attr("data-auto_choose");
+        if($(item).hasClass("chained-fk")) {
+            var empty_label = $(item).attr("data-empty_label");
+            chainedfk.init(chainfield, url, id, value, empty_label, auto_choose);
+        } else if ($(item).hasClass("chained-m2m")) {
+            chainedm2m.init(chainfield, url, id, value, auto_choose);
+        }
+    }
+    $(window).load(function() {
+        $.each($(".chained-m2m"), function(index, item) {
+            initItem(item);
+        });
+    });
+
+    $(document).ready(function(){
+        $.each($(".chained-fk"), function(index, item) {
+            initItem(item);
+        })
+    });
+    // Fired every time a new inline formset is created
+    django.jQuery(document).on('formset:added', function(event, $row, formsetName) {
+        var chained = $row.find(".chained-fk");
+        var chainfield = $(chained).attr("data-chainfield");
+        if (chainfield.indexOf("__prefix__") > -1) {
+            /*
+            If we have several inlines with the same name, they will get an index, so we need to ignore that and get
+            the last numeric value in the id
+            */
+            var chainedId = $(chained).attr("id");
+            var re = /\d+/g;
+            var prefix;
+            var match;
+            do {
+                match = re.exec(chainedId);
+                if (match) {
+                    prefix = match[0];
+                }
+            } while (match);
+
+            chainfield = chainfield.replace("__prefix__", prefix);
+            $(chained).attr("data-chainfield", chainfield)
+        }
+        initItem(chained);
+     });
+})(jQuery || django.jQuery);

--- a/smart_selects/widgets.py
+++ b/smart_selects/widgets.py
@@ -261,7 +261,6 @@ class ChainedSelectMultiple(JqueryMediaMixin, SelectMultiple):
         # js = """
         # <script type="text/javascript">
         # (function($) {
-        # 
         # var chainfield = "#id_%(chainfield)s";
         # var url = "%(url)s";
         # var id = "#%(id)s";
@@ -273,7 +272,6 @@ class ChainedSelectMultiple(JqueryMediaMixin, SelectMultiple):
         # });
         # })(jQuery || django.jQuery);
         # </script>
-        # 
         # """
         # js = js % {"chainfield": chain_field,
         #            "url": url,

--- a/smart_selects/widgets.py
+++ b/smart_selects/widgets.py
@@ -145,7 +145,7 @@ class ChainedSelect(JqueryMediaMixin, Select):
 
         attrs["data-chainfield"] = chained_field
         attrs["data-url"] = url
-        attrs["data-value"] = "undefined" if value is None or value == "" else value
+        attrs["data-value"] = "null" if value is None or value == "" else value
         attrs["data-auto_choose"] = auto_choose
         attrs["data-empty_label"] = escape(empty_label)
         if value:
@@ -281,7 +281,7 @@ class ChainedSelectMultiple(JqueryMediaMixin, SelectMultiple):
 
         attrs["data-chainfield"] = chain_field
         attrs["data-url"] = url
-        attrs["data-value"] = '""' if value is None else json.dumps(value)
+        attrs["data-value"] = "null" if value is None else json.dumps(value)
         attrs["data-auto_choose"] = auto_choose
 
         # since we cannot deduce the value of the chained_field

--- a/test_app/tests.py
+++ b/test_app/tests.py
@@ -86,7 +86,6 @@ class ViewTests(TestCase):
     def test_book_add_get(self):
         response = self.client.get(reverse('admin:test_app_book_add'))
         self.assertContains(response, 'Publication 1')
-        print response
         self.assertContains(response, 'data-value="&quot;&quot;"')
 
     def test_book_add_post(self):

--- a/test_app/tests.py
+++ b/test_app/tests.py
@@ -86,7 +86,8 @@ class ViewTests(TestCase):
     def test_book_add_get(self):
         response = self.client.get(reverse('admin:test_app_book_add'))
         self.assertContains(response, 'Publication 1')
-        self.assertContains(response, 'data-value=""')
+        print response
+        self.assertContains(response, 'data-value="&quot;&quot;"')
 
     def test_book_add_post(self):
         post_data = {

--- a/test_app/tests.py
+++ b/test_app/tests.py
@@ -24,7 +24,7 @@ class ViewTests(TestCase):
         response = self.client.get(reverse('admin:test_app_location_add'), follow=True)
         self.assertContains(response, 'Europe')
         self.assertContains(response, 'America')
-        self.assertContains(response, 'var value = undefined;')
+        self.assertContains(response, 'data-value="undefined"')
 
     def test_location_add_post(self):
         post_data = {
@@ -47,12 +47,12 @@ class ViewTests(TestCase):
         }
         response = self.client.post(reverse('admin:test_app_location_add'), post_data)
         self.assertContains(response, 'This field is required.')
-        self.assertContains(response, 'var value = undefined;')
+        self.assertContains(response, 'data-value="undefined"')
 
     def test_location_change_get(self):
         response = self.client.get(reverse('admin:test_app_location_change', args=(1,)))
         self.assertContains(response, 'Europe')
-        self.assertContains(response, 'var value = 1')
+        self.assertContains(response, 'data-value="1"')
 
     def test_filterchain_view_for_chained_foreignkey(self):
         request = self.factory.get('')
@@ -86,7 +86,7 @@ class ViewTests(TestCase):
     def test_book_add_get(self):
         response = self.client.get(reverse('admin:test_app_book_add'))
         self.assertContains(response, 'Publication 1')
-        self.assertContains(response, 'var value = ""')
+        self.assertContains(response, 'data-value=""')
 
     def test_book_add_post(self):
         post_data = {
@@ -105,11 +105,11 @@ class ViewTests(TestCase):
         }
         response = self.client.post(reverse('admin:test_app_book_add'), post_data)
         self.assertContains(response, 'This field is required.')
-        self.assertContains(response, 'var value = []')
+        self.assertContains(response, 'data-value="[]"')
 
     def test_book_change_get(self):
         response = self.client.get(reverse('admin:test_app_book_change', args=(1,)), follow=True)
-        self.assertContains(response, 'var value = [3];')
+        self.assertContains(response, 'data-value="[3]"')
 
     def test_filterchain_view_for_chained_manytomany(self):
         request = self.factory.get('')

--- a/test_app/tests.py
+++ b/test_app/tests.py
@@ -24,7 +24,7 @@ class ViewTests(TestCase):
         response = self.client.get(reverse('admin:test_app_location_add'), follow=True)
         self.assertContains(response, 'Europe')
         self.assertContains(response, 'America')
-        self.assertContains(response, 'data-value="undefined"')
+        self.assertContains(response, 'data-value="null"')
 
     def test_location_add_post(self):
         post_data = {
@@ -47,7 +47,7 @@ class ViewTests(TestCase):
         }
         response = self.client.post(reverse('admin:test_app_location_add'), post_data)
         self.assertContains(response, 'This field is required.')
-        self.assertContains(response, 'data-value="undefined"')
+        self.assertContains(response, 'data-value="null"')
 
     def test_location_change_get(self):
         response = self.client.get(reverse('admin:test_app_location_change', args=(1,)))
@@ -86,7 +86,7 @@ class ViewTests(TestCase):
     def test_book_add_get(self):
         response = self.client.get(reverse('admin:test_app_book_add'))
         self.assertContains(response, 'Publication 1')
-        self.assertContains(response, 'data-value="&quot;&quot;"')
+        self.assertContains(response, 'data-value="null"')
 
     def test_book_add_post(self):
         post_data = {


### PR DESCRIPTION
This PR tries to solve #193 by externalizing chained field initialization.

Instead of adding a script to every chained field, there is a new function which looks at all elements with the class "chained-fk" and "chained-m2m" and calls the corresponding init method.

Furthermore, using the formset:added event from Django (see https://docs.djangoproject.com/en/1.11/releases/1.9/#django-contrib-admin or https://code.djangoproject.com/ticket/15760), fields from new inline formsets get initializet. This is compatible with Django 1.9+, but it won't cause problems in prior versions as the event will not get fired.