### PR TITLE
Django 1.11 compatibility

### DIFF
--- a/smart_selects/widgets.py
+++ b/smart_selects/widgets.py
@@ -157,7 +157,8 @@ class ChainedSelect(JqueryMediaMixin, Select):
                     final_choices.append(ch)
         self.choices = final_choices
 
-        final_attrs = self.build_attrs(attrs, name=name)
+        attrs["name"] = name
+        final_attrs = self.build_attrs(attrs)
         if 'class' in final_attrs:
             final_attrs['class'] += ' chained'
         else:
@@ -278,7 +279,8 @@ class ChainedSelectMultiple(JqueryMediaMixin, SelectMultiple):
         # fetch related choices later
         final_choices = []
         self.choices = final_choices
-        final_attrs = self.build_attrs(attrs, name=name)
+        attrs["name"] = name
+        final_attrs = self.build_attrs(attrs)
         if 'class' in final_attrs:
             final_attrs['class'] += ' chained'
         else:

--- a/test_app/tests.py
+++ b/test_app/tests.py
@@ -130,9 +130,9 @@ class ViewTests(TestCase):
     def test_student_add_get(self):
         response = self.client.get(reverse('admin:test_app_student_add'))
         # For some reason, Django 1.11 renders this with additional new lines and spaces, so we strip all of them off
-        splitted = response.content.split('\n')
-        splitted = [part.lstrip(' \t\n\r') for part in splitted]
-        response.content = ''.join(splitted)
+        splitted = response.content.split(b'\n')
+        splitted = [part.lstrip(b' \t\n\r') for part in splitted]
+        response.content = b''.join(splitted)
         self.assertContains(response, '<optgroup label="Grade 1"><option value="1">   Team 1</option></optgroup>')
         self.assertContains(response, '<optgroup label="Grade 2"><option value="2">   Team 2</option></optgroup>')
 

--- a/test_app/tests.py
+++ b/test_app/tests.py
@@ -1,3 +1,5 @@
+import re
+
 from django.core.urlresolvers import reverse
 from django.test import TestCase, RequestFactory
 from .models import Book, Country, Location, Student
@@ -129,8 +131,12 @@ class ViewTests(TestCase):
     # grouped foreignkey
     def test_student_add_get(self):
         response = self.client.get(reverse('admin:test_app_student_add'))
-        self.assertContains(response, '<optgroup label="Grade 1">\n<option value="1">   Team 1</option>\n</optgroup>')
-        self.assertContains(response, '<optgroup label="Grade 2">\n<option value="2">   Team 2</option>\n</optgroup>')
+        # For some reason, Django 1.11 renders this with additional new lines and spaces, so we strip all of them off
+        splitted = response.content.split('\n')
+        splitted = [part.lstrip(' \t\n\r') for part in splitted]
+        response.content = ''.join(splitted)
+        self.assertContains(response, '<optgroup label="Grade 1"><option value="1">   Team 1</option></optgroup>')
+        self.assertContains(response, '<optgroup label="Grade 2"><option value="2">   Team 2</option></optgroup>')
 
     def test_student_add_post(self):
         post_data = {

--- a/test_app/tests.py
+++ b/test_app/tests.py
@@ -64,8 +64,8 @@ class ViewTests(TestCase):
     def test_filterchain_all_view_for_chained_foreignkey(self):
         request = self.factory.get('')
         response = filterchain_all(request, 'test_app', 'Country', 'continent', 'test_app', 'Location', 'country', 1)
-        expected_value = '[{"display": "Czech republic", "value": 1}, {"display": "Germany", "value": 3},'\
-            ' {"display": "Great Britain", "value": 4}, {"display": "---------", "value": ""}, {"display": "New York", "value": 2}]'
+        expected_value = '[{"display": "Czech republic", "value": 1}, {"display": "Germany", "value": 3},' \
+                         ' {"display": "Great Britain", "value": 4}, {"display": "---------", "value": ""}, {"display": "New York", "value": 2}]'
         self.assertEquals(response.status_code, 200)
         self.assertJSONEqual(response.content.decode(), expected_value)
 
@@ -129,12 +129,10 @@ class ViewTests(TestCase):
     # grouped foreignkey
     def test_student_add_get(self):
         response = self.client.get(reverse('admin:test_app_student_add'))
-        # For some reason, Django 1.11 renders this with additional new lines and spaces, so we strip all of them off
-        splitted = response.content.split(b'\n')
-        splitted = [part.lstrip(b' \t\n\r') for part in splitted]
-        response.content = b''.join(splitted)
-        self.assertContains(response, '<optgroup label="Grade 1"><option value="1">   Team 1</option></optgroup>')
-        self.assertContains(response, '<optgroup label="Grade 2"><option value="2">   Team 2</option></optgroup>')
+        self.assertContains(response, '<optgroup label="Grade 1">\n<option value="1">   Team 1</option>\n</optgroup>',
+                            html=True)
+        self.assertContains(response, '<optgroup label="Grade 2">\n<option value="2">   Team 2</option>\n</optgroup>',
+                            html=True)
 
     def test_student_add_post(self):
         post_data = {

--- a/test_app/tests.py
+++ b/test_app/tests.py
@@ -1,5 +1,3 @@
-import re
-
 from django.core.urlresolvers import reverse
 from django.test import TestCase, RequestFactory
 from .models import Book, Country, Location, Student


### PR DESCRIPTION
Django 1.11 has changed Widget.build_attrs and now it doesn't accept kwargs, so some adjustments need to be made in order to make them compatible with this version.

Also, when rendering a response for a test, it adds additional new lines and whitespaces, so this test failed. All these additional characters were removed from the response and now all tests pass for current master.

Tested with django 1.8 to 1.11