### PR TITLE
Fix StopIteration Exception for django-bootstrap3 field without choices

### DIFF
--- a/smart_selects/widgets.py
+++ b/smart_selects/widgets.py
@@ -105,12 +105,15 @@ class ChainedSelect(JqueryMediaMixin, Select):
             auto_choose = 'true'
         else:
             auto_choose = 'false'
-        iterator = iter(self.choices)
-        if hasattr(iterator, '__next__'):
-            empty_label = iterator.__next__()[1]
+        if choices:
+	        iterator = iter(self.choices)
+	        if hasattr(iterator, '__next__'):
+	            empty_label = iterator.__next__()[1]
+	        else:
+	            # Hacky way to getting the correct empty_label from the field instead of a hardcoded '--------'
+	            empty_label = iterator.next()[1]
         else:
-            # Hacky way to getting the correct empty_label from the field instead of a hardcoded '--------'
-            empty_label = iterator.next()[1]
+	    	empty_label = "--------"
 
         final_choices = []
 

--- a/smart_selects/widgets.py
+++ b/smart_selects/widgets.py
@@ -106,14 +106,14 @@ class ChainedSelect(JqueryMediaMixin, Select):
         else:
             auto_choose = 'false'
         if choices:
-	        iterator = iter(self.choices)
-	        if hasattr(iterator, '__next__'):
-	            empty_label = iterator.__next__()[1]
-	        else:
-	            # Hacky way to getting the correct empty_label from the field instead of a hardcoded '--------'
-	            empty_label = iterator.next()[1]
+            iterator = iter(self.choices)
+            if hasattr(iterator, '__next__'):
+                empty_label = iterator.__next__()[1]
+            else:
+                # Hacky way to getting the correct empty_label from the field instead of a hardcoded '--------'
+                empty_label = iterator.next()[1]
         else:
-	    	empty_label = "--------"
+            empty_label = "--------"
 
         final_choices = []
 


### PR DESCRIPTION
When using `ChainedModelChoiceField` for a field which has no choices,
in conjunction with `django-bootstrap3`, a `StopIteration` Exception is
thrown while trying to identify the default empty label. This commit
adds a check for that situation and replaces the empty label with the
hardcoded default `"--------"`

This commit is the same functional diff as SerhiyRomanov@275c46098a4151a806652b885454310a9addfd05
for #198 but reapplied against current master.