### PR TITLE
#215 Replace django.core.urlresolvers with django.urls (RemovedInDjango20Warning)

### DIFF
--- a/smart_selects/widgets.py
+++ b/smart_selects/widgets.py
@@ -4,11 +4,17 @@ import django
 
 from django.apps import apps
 from django.conf import settings
-from django.core.urlresolvers import reverse
 from django.forms.widgets import Select, SelectMultiple
 from django.utils.safestring import mark_safe
 from django.utils.encoding import force_text
 from django.utils.html import escape
+
+try:
+    # Django >= 1.10
+    from django.urls import reverse
+except ImportError:
+    # Django < 1.10
+    from django.core.urlresolvers import reverse
 
 from smart_selects.utils import unicode_sorter, sort_results
 

--- a/test_app/tests.py
+++ b/test_app/tests.py
@@ -1,7 +1,15 @@
-from django.core.urlresolvers import reverse
 from django.test import TestCase, RequestFactory
-from .models import Book, Country, Location, Student
+
+try:
+    # Django >= 1.10
+    from django.urls import reverse
+except ImportError:
+    # Django < 1.10
+    from django.core.urlresolvers import reverse
+
 from smart_selects.views import filterchain, filterchain_all, is_m2m
+
+from .models import Book, Country, Location, Student
 
 
 class ModelTests(TestCase):


### PR DESCRIPTION
Closes #215

Replaces all instances of `django.core.urlresolvers` with `django.urls`, as per the recommendation in the [Django 1.10 release notes](https://docs.djangoproject.com/en/1.10/releases/1.10/#id3).

I just a `try/except` block to do the import-choosing. Let me know if you prefer a different approach (`if/else`, for example).