### PR TITLE
#217 Replace Field.rel with Field.remote_field (RemovedInDjango20Warning)

### DIFF
--- a/smart_selects/db_fields.py
+++ b/smart_selects/db_fields.py
@@ -118,8 +118,8 @@ class ChainedManyToManyField(IntrospectiveFieldMixin, ManyToManyField):
         foreign_key_field_name = self.name
         defaults = {
             'form_class': form_fields.ChainedManyToManyField,
-            'queryset': self.rel.to._default_manager.complex_filter(
-                self.rel.limit_choices_to),
+            'queryset': self.remote_field.to._default_manager.complex_filter(
+                self.remote_field.limit_choices_to),
             'to_app_name': self.to_app_name,
             'to_model_name': self.to_model_name,
             'chain_field': self.chain_field,
@@ -228,9 +228,9 @@ class ChainedForeignKey(IntrospectiveFieldMixin, ForeignKey):
         foreign_key_field_name = self.name
         defaults = {
             'form_class': form_fields.ChainedModelChoiceField,
-            'queryset': self.rel.to._default_manager.complex_filter(
-                self.rel.limit_choices_to),
-            'to_field_name': self.rel.field_name,
+            'queryset': self.remote_field.to._default_manager.complex_filter(
+                self.remote_field.limit_choices_to),
+            'to_field_name': self.remote_field.field_name,
             'to_app_name': self.to_app_name,
             'to_model_name': self.to_model_name,
             'chained_field': self.chained_field,
@@ -274,9 +274,9 @@ class GroupedForeignKey(ForeignKey):
     def formfield(self, **kwargs):
         defaults = {
             'form_class': form_fields.GroupedModelSelect,
-            'queryset': self.rel.to._default_manager.complex_filter(
-                self.rel.limit_choices_to),
-            'to_field_name': self.rel.field_name,
+            'queryset': self.remote_field.to._default_manager.complex_filter(
+                self.remote_field.limit_choices_to),
+            'to_field_name': self.remote_field.field_name,
             'order_field': self.group_field,
         }
         defaults.update(kwargs)

--- a/smart_selects/utils.py
+++ b/smart_selects/utils.py
@@ -30,7 +30,7 @@ def get_limit_choices_to(app_name, model_name, field_name):
     try:
         model = get_model(app_name, model_name)
         field = model._meta.get_field(field_name)
-        limit_choices_to = field.rel.limit_choices_to
+        limit_choices_to = field.remote_field.limit_choices_to
     except Exception:
         limit_choices_to = None
 


### PR DESCRIPTION
Closes #217

Replaces all instances of `Field.rel` with `Field.remote_field`, as per the recommendation in the [Django 1.9 release notes](https://docs.djangoproject.com/en/1.9/releases/1.9/#field-rel-changes).