### PR TITLE
Fix issue #212.

### DIFF
--- a/smart_selects/static/smart-selects/admin/js/chainedm2m.js
+++ b/smart_selects/static/smart-selects/admin/js/chainedm2m.js
@@ -43,8 +43,18 @@
                     }
                 }
 
+                // SelectBox is a global var from djangojs "admin/js/SelectBox.js"
+                // Clear cache to avoid the elements duplication
+                if (typeof SelectBox.cache[cache_to] !== 'undefined') {
+                    SelectBox.cache[cache_to].splice(0);
+                }
+                if (typeof SelectBox.cache[cache_from] !== 'undefined') {
+                    SelectBox.cache[cache_from].splice(0);
+                }
+
                 if (!val || val === ''){
                     $selectField.html('');
+                    $selectedto.html('');
                     trigger_chosen_updated();
                     return;
                 }

--- a/smart_selects/widgets.py
+++ b/smart_selects/widgets.py
@@ -199,13 +199,13 @@ class ChainedSelectMultiple(JqueryMediaMixin, SelectMultiple):
     def media(self):
         """Media defined as a dynamic property instead of an inner class."""
         media = super(ChainedSelectMultiple, self).media
+        media.add_js(['smart-selects/admin/js/chainedm2m.js'])
+        media.add_js(['smart-selects/admin/js/bindfields.js'])
         if self.horizontal:
             # For horizontal mode add django filter horizontal javascript code
             js = ["core.js", "SelectBox.js", "SelectFilter2.js"]
             for path in js:
                 media.add_js(["admin/js/%s" % path])
-        media.add_js(['smart-selects/admin/js/chainedm2m.js'])
-        media.add_js(['smart-selects/admin/js/bindfields.js'])
         return media
 
     def render(self, name, value, attrs=None, choices=()):


### PR DESCRIPTION
Fix issue #212 

Load javascript for horizontal mode after ours javascript files because the
horizontal mode javascript files will change the template and remove the class
".chained" that is used to initialize the element.

When using the horizontal mode, clean the cache in fill_field to avoid the
duplication of elements.

How to validate:
- Modify the model Books in the `test_app/models.py` to use the horizontal mode

```
diff --git a/test_app/models.py b/test_app/models.py
index a6900af..9d2abff 100644
--- a/test_app/models.py
+++ b/test_app/models.py
@@ -70,6 +70,7 @@ class Book(models.Model):
         Writer,
         chained_field="publication",
         chained_model_field="publications",
+        horizontal=True,
         )
     name = models.CharField(max_length=255)
```
- Add severals Writers and Publications
- Go to the page http://127.0.0.1:8000/admin/test_app/book/add/ to add a Book.
- Validate that the widget for writer works as expected.