### PR TITLE
Update bindfields.js

### DIFF
--- a/smart_selects/static/smart-selects/admin/js/bindfields.js
+++ b/smart_selects/static/smart-selects/admin/js/bindfields.js
@@ -15,7 +15,7 @@
         }
     }
 
-    $(window).load(function () {
+    $(window).on('load', function () {
         $.each($(".chained"), function (index, item) {
             initItem(item);
         });
@@ -51,7 +51,7 @@
         initItem(chained);
     }
 
-    django.jQuery(document).on('formset:added', function (event, $row, formsetName) {
+    $(document).on('formset:added', function (event, $row, formsetName) {
         // Fired every time a new inline formset is created
 
         // For the ForeingKey


### PR DESCRIPTION
As I was using smart_selects into my template, i couln't make your module works :
As $(window).load(function ().. is depreciated since Jquery v3, I would like to change it by $(window).on('load', function () {
This solved the following error : 
Uncaught TypeError: a.indexOf is not a function
at r.fn.init.r.fn.load (jquery.min.js:4)
at bindfields.js:18
at bindfields.js:69

Also as jQuery doesn't belong to django anymore and as I am loading jQuery from my html template I'd like to remplace django.jQuery(document) by $(document). This solved the message error : Uncaught ReferenceError : django is not defined at bindfields.js:54 and at at bindfields.js:69

sources : https://stackoverflow.com/questions/37738732/jquery-3-0-url-indexof-error
https://stackoverflow.com/questions/34911810/django-admin-django-is-not-defined