### PR TITLE
Fix to work with jQuery 3

### DIFF
--- a/smart_selects/static/smart-selects/admin/js/bindfields.js
+++ b/smart_selects/static/smart-selects/admin/js/bindfields.js
@@ -15,7 +15,7 @@
         }
     }
 
-    $(window).load(function () {
+    $(window).on('load', function() {
         $.each($(".chained"), function (index, item) {
             initItem(item);
         });


### PR DESCRIPTION
Thanks to "cuz" (https://stackoverflow.com/questions/37738732/jquery-3-0-url-indexof-error), fix to smart-selects work with jQuery 3.

(Need more tests, I only made "ChainedForeignKey" work).

Issue #197 