### PR TITLE
Add change trigger on raw_id_fields for m2m

### DIFF
--- a/smart_selects/static/smart-selects/admin/js/chainedm2m.js
+++ b/smart_selects/static/smart-selects/admin/js/chainedm2m.js
@@ -156,6 +156,15 @@
                         }
                     };
                 }
+                if (typeof(dismissRelatedLookupPopup) !== 'undefined') {
+                    var oldDismissRelatedLookupPopup = dismissRelatedLookupPopup;
+                    dismissRelatedLookupPopup = function(win, chosenId) {
+                        oldDismissRelatedLookupPopup(win, chosenId);
+                        if ("#" + windowname_to_id(win.name) == chainfield) {
+                            $(chainfield).change();
+                        }
+                    };
+                }
             }
         };
     }();


### PR DESCRIPTION
Looks like the change function is not triggered if the field value is changed when using the `raw_id_fields` (popup).
Adding the trigger by overwriting `dismissRelatedLookupPopup` is necessary until django admin fixes this. 

Similar to how `dismissAddAnotherPopup` is changed as well.

Open to feedback on how to do this better