### PR TITLE
Bug fix calling pk on None in case if group field is not set for item.

### DIFF
--- a/smart_selects/form_fields.py
+++ b/smart_selects/form_fields.py
@@ -74,7 +74,7 @@ class GroupedModelSelect(ModelChoiceField):
         i = len(choices)
         for item in self.queryset:
             order_field = getattr(item, self.order_field)
-            group_index = order_field.pk
+            group_index = order_field and order_field.pk
             if group_index not in group_indexes:
                 group_indexes[group_index] = i
                 choices.append([force_text(order_field), []])


### PR DESCRIPTION
Trying on Django 1.10, got:
```
File "/usr/local/lib/python2.7/site-packages/smart_selects/form_fields.py", line 77, in _get_choices
     group_index = order_field.pk
 AttributeError: 'NoneType' object has no attribute 'pk'
```
Discovered, the reason is some of my group fields is blank. The group index now "None", it might me more human friendly...