### PR TITLE
Indicate support for Python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,4 +16,8 @@ setup(name="django-smart-selects",
       tests_require=[
           'flake8',
       ],
+      classifiers=[
+          'Programming Language :: Python :: 2',
+          'Programming Language :: Python :: 3',
+      ],
       )


### PR DESCRIPTION
This is useful for certain sites like Django Packages. That way, it easy to programmatically detect whether the package is meant to support Python 3. For example, it would be nice if this link indicated that django-smart-selects supported Python 3:

https://djangopackages.org/grids/g/auto-complete/

I'm assuming that this package does indeed support Python 3. If not, this classifier should be used instead: "Programming Language :: Python :: 2 :: Only"