### PR TITLE
Ignore fields with __prefix__ in id

### DIFF
--- a/smart_selects/static/smart-selects/admin/js/bindfields.js
+++ b/smart_selects/static/smart-selects/admin/js/bindfields.js
@@ -7,6 +7,10 @@
             id = "#" + $(item).attr("id"),
             value = JSON.parse($(item).attr("data-value")),
             auto_choose = $(item).attr("data-auto_choose");
+        // Ignore fields that aren't displayed on-screen yet
+        if (id.indexOf('__prefix__') !== -1) {
+          return;
+        }
         if ($(item).hasClass("chained-fk")) {
             empty_label = $(item).attr("data-empty_label");
             chainedfk.init(chainfield, url, id, value, empty_label, auto_choose);


### PR DESCRIPTION
django-smart-selects is currently initialising fields that aren't displayed on screen (including `__prefix__` in the id)
https://docs.djangoproject.com/en/3.2/topics/forms/formsets/#empty-form

These are usually created for one/many-to-many relationships, and are cloned when a user clicks on the "add another" within the admin. The `__prefix__` is then [replaced with an index number](https://github.com/django/django/blob/ca9872905559026af82000e46cde6f7dedc897b6/django/contrib/admin/static/admin/js/inlines.js#L25-L37) (starting at 0)

There is a lot of code spread around to skip fields that include `__prefix__`:
https://github.com/django/django/blob/ca9872905559026af82000e46cde6f7dedc897b6/django/contrib/admin/static/admin/js/SelectFilter2.js#L11-L14
https://github.com/django/django/blob/ca9872905559026af82000e46cde6f7dedc897b6/django/contrib/admin/static/admin/js/autocomplete.js#L33
