### PR TITLE
Fix row in formset event

### DIFF
--- a/smart_selects/static/smart-selects/admin/js/bindfields.js
+++ b/smart_selects/static/smart-selects/admin/js/bindfields.js
@@ -61,11 +61,11 @@
         initItem(chained);
     }
 
-    $(document).on('formset:added', function (event) {
+    $(document).on('formset:added', function (event, _row) {
         // Fired every time a new inline formset is created
 
         var chainedFK, chainedM2M, filteredM2M;
-        var $row = $(event.target);
+        var $row = _row || $(event.target);
 
         // For the ForeingKey
         chainedFK = $row.find(".chained-fk");

--- a/smart_selects/static/smart-selects/admin/js/bindfields.js
+++ b/smart_selects/static/smart-selects/admin/js/bindfields.js
@@ -61,10 +61,11 @@
         initItem(chained);
     }
 
-    $(document).on('formset:added', function (event, $row, formsetName) {
+    $(document).on('formset:added', function (event) {
         // Fired every time a new inline formset is created
 
         var chainedFK, chainedM2M, filteredM2M;
+        var $row = $(event.target);
 
         // For the ForeingKey
         chainedFK = $row.find(".chained-fk");


### PR DESCRIPTION
I upgraded to Django 4.2+ a project that uses django-smart-selects and I noticed an error from binfields.js.

After investigating, I found that Django 4.1 removed $row and formsetName parameters.

> Changed in Django 4.1:
> In older versions, the event was a jQuery event with $row and formsetName parameters. It is now a JavaScript CustomEvent with parameters set in event.detail.

Source : https://docs.djangoproject.com/en/4.2/ref/contrib/admin/javascript/#inline-form-events